### PR TITLE
Set drips per minute regardless of current state.

### DIFF
--- a/dripper/dripper.go
+++ b/dripper/dripper.go
@@ -104,6 +104,10 @@ func (d *Dripper) Drip(dripsPerMin float64) error {
 		return err
 	}
 
+	// We are setting dripsPerMin before the sanity check in order to update
+	// regardless.
+	d.dripsPerMin = dripsPerMin
+
 	// This is a sanity check to ensure the dripper is not already in the drip
 	// state.
 	if d.state == DRIP {
@@ -111,7 +115,6 @@ func (d *Dripper) Drip(dripsPerMin float64) error {
 	}
 
 	d.state = DRIP
-	d.dripsPerMin = dripsPerMin
 
 	d.dripperWG.Add(1)
 	go d.runDrip()


### PR DESCRIPTION
This commit moves the setting of drips per minute in the drip function above
the sanity check in order to properly set the drip rate if the dripper is set
to drip while already dripping with a new drip rate.